### PR TITLE
Rename debounce to prevent conflict

### DIFF
--- a/templates/main.hbs
+++ b/templates/main.hbs
@@ -66,7 +66,7 @@
 </footer>
 
 <script type="text/javascript">
-    function debounce(func, wait) {
+    function faDebounce(func, wait) {
         let timeout;
         return function () {
             const context = this,
@@ -106,6 +106,6 @@
         }
     }
 
-    $('#faFilter').on('keyup', debounce(filterMaps, 150));
+    $('#faFilter').on('keyup', faDebounce(filterMaps, 150));
     $('#faFilter').on('search', filterMaps);
 </script>


### PR DESCRIPTION
Fix for v12 conflicting function names and preventing the map search from working