### PR TITLE
Fix support for opening compendium viewer

### DIFF
--- a/scripts/fa-battlemaps.js
+++ b/scripts/fa-battlemaps.js
@@ -191,7 +191,7 @@ Hooks.on('renderCompendium', async function (e) {
   let shouldShow;
   // V13 changed the way the id is stored
   if (e.id) { // v13
-    shouldShow = e.id === 'fa-battlemaps.maps';
+    shouldShow = e.id === 'compendium-fa-battlemaps_maps' || e.id === 'fa-battlemaps.maps';
   } else { // v12
     shouldShow = (e.metadata.id ?? e.metadata.package + '.' + e.metadata.name) === 'fa-battlemaps.maps';
   }


### PR DESCRIPTION
Looks like v13 changed the compendium id format again, so handle this case as well when opening the compendium from the sidebar (rather than from the button on the Scenes tab).